### PR TITLE
fix: add new decorator type for decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,31 @@
 [![npm version](https://badge.fury.io/js/adonis-odm.svg)](https://www.npmjs.com/package/adonis-odm)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A MongoDB Object Document Mapper (ODM) for AdonisJS v6 that provides a familiar Lucid ORM-like interface for working with MongoDB databases.
+A comprehensive MongoDB Object Document Mapper (ODM) for AdonisJS v6 that provides a familiar Lucid ORM-like interface for working with MongoDB databases. Built with TypeScript for maximum type safety and developer experience.
 
-## Features
+## ✨ Features
 
-- 🎯 **Familiar API**: Similar to AdonisJS Lucid ORM for easy adoption
-- 🏗️ **Decorator-based Models**: Use decorators to define your model schema
+### Core Features
+
+- 🎯 **Familiar API**: 100% Lucid ORM-compatible interface for easy adoption
+- 🏗️ **Decorator-based Models**: Use decorators to define your model schema and relationships
 - 🔍 **Fluent Query Builder**: Chainable query methods with MongoDB-specific operations
 - 📅 **Automatic Timestamps**: Auto-managed `createdAt` and `updatedAt` fields
 - 🔄 **Model Lifecycle**: Track model state with `$isPersisted`, `$dirty`, etc.
-- 📄 **Pagination**: Built-in pagination support
+- 📄 **Pagination**: Built-in pagination support with metadata
 - 🔗 **Connection Management**: Multiple MongoDB connection support
-- 🛡️ **Type Safety**: Full TypeScript support with IntelliSense
+- 🛡️ **Type Safety**: Full TypeScript support with IntelliSense and compile-time checking
+
+### Advanced Features
+
 - 💾 **Database Transactions**: Full ACID transaction support with managed and manual modes
 - 📦 **Embedded Documents**: Type-safe embedded document support with full CRUD operations
-- 🔗 **Relationships**: Type-safe referenced and embedded relationships with query builders
+- 🔗 **Relationships**: Type-safe referenced relationships (@hasOne, @hasMany, @belongsTo)
+- 🪝 **Lifecycle Hooks**: Comprehensive hook system (beforeSave, afterSave, beforeCreate, etc.)
+- 🔍 **Advanced Querying**: Complex filtering, aggregation, and embedded document querying
+- ⚡ **Performance**: Bulk operations, connection pooling, and optimized queries
+- 🛠️ **CLI Tools**: Ace commands for model generation and database operations
+- 🧪 **Testing Support**: Built-in testing utilities and Docker integration
 
 ## Installation
 
@@ -97,12 +107,17 @@ export default odmConfig
 The following environment variables are used by the MongoDB configuration:
 
 ```env
+# Basic Connection Settings
 MONGO_HOST=localhost
 MONGO_PORT=27017
 MONGO_DATABASE=your_database_name
 MONGO_URI=mongodb://localhost:27017/your_database_name
 
-# Optional connection pool settings
+# Authentication (optional)
+MONGO_USERNAME=your_username
+MONGO_PASSWORD=your_password
+
+# Connection Pool Settings (optional)
 MONGO_MAX_POOL_SIZE=10
 MONGO_MIN_POOL_SIZE=0
 MONGO_MAX_IDLE_TIME_MS=30000
@@ -110,6 +125,8 @@ MONGO_SERVER_SELECTION_TIMEOUT_MS=5000
 MONGO_SOCKET_TIMEOUT_MS=0
 MONGO_CONNECT_TIMEOUT_MS=10000
 ```
+
+**Note**: You can use either `MONGO_URI` for a complete connection string, or individual components (`MONGO_HOST`, `MONGO_PORT`, etc.). The URI takes precedence if both are provided.
 
 ### Multiple Connections
 
@@ -287,16 +304,18 @@ export default class User extends BaseModel {
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
 
-  // Computed properties
+  // Computed properties (using @computed decorator for serialization)
+  @computed()
   get fullName(): string | null {
     return this.profile?.fullName || null
   }
 
+  @computed()
   get allProfileNames(): string[] {
     return this.profiles?.map((p) => p.fullName) || []
   }
 
-  // Helper methods
+  // Helper methods (regular methods, not computed properties)
   getYoungProfiles(maxAge: number): InstanceType<typeof Profile>[] {
     return this.profiles?.filter((p) => p.age < maxAge) || []
   }
@@ -491,18 +510,169 @@ const users = await User.query()
 
 ### Referenced Relationships
 
-For traditional referenced relationships, use the `.load()` method:
+The ODM provides full support for traditional referenced relationships with type-safe decorators and automatic loading.
+
+#### Defining Referenced Relationships
 
 ```typescript
-// Load referenced relationships
+import { BaseModel, column, hasOne, hasMany, belongsTo } from 'adonis-odm'
+import type { HasOne, HasMany, BelongsTo } from 'adonis-odm'
+
+// User model with relationships
+export default class User extends BaseModel {
+  @column({ isPrimary: true })
+  declare _id: string
+
+  @column()
+  declare name: string
+
+  @column()
+  declare email: string
+
+  // One-to-one relationship
+  @hasOne(() => Profile)
+  declare profile: HasOne<typeof Profile>
+
+  // One-to-many relationship
+  @hasMany(() => Post)
+  declare posts: HasMany<typeof Post>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}
+
+// Profile model with belongs-to relationship
+export default class Profile extends BaseModel {
+  @column({ isPrimary: true })
+  declare _id: string
+
+  @column()
+  declare firstName: string
+
+  @column()
+  declare lastName: string
+
+  @column()
+  declare userId: string
+
+  // Many-to-one relationship
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}
+
+// Post model
+export default class Post extends BaseModel {
+  @column({ isPrimary: true })
+  declare _id: string
+
+  @column()
+  declare title: string
+
+  @column()
+  declare content: string
+
+  @column()
+  declare authorId: string
+
+  // Many-to-one relationship
+  @belongsTo(() => User, { foreignKey: 'authorId' })
+  declare author: BelongsTo<typeof User>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}
+```
+
+#### Loading Referenced Relationships
+
+Use the `.load()` method for type-safe relationship loading:
+
+```typescript
+// Load single relationship
 const users = await User.query().load('profile').where('isActive', true).all()
 
-// Load with filtering callback
+// Load multiple relationships
+const users = await User.query().load('profile').load('posts').all()
+
+// Load with filtering callback - Full IntelliSense support!
 const users = await User.query()
   .load('profile', (profileQuery) => {
     profileQuery.where('isPublic', true).orderBy('updatedAt', 'desc')
   })
+  .load('posts', (postQuery) => {
+    postQuery.where('isPublished', true).orderBy('createdAt', 'desc').limit(5)
+  })
   .all()
+
+// Nested relationship loading
+const users = await User.query()
+  .load('posts', (postQuery) => {
+    postQuery.load('comments').where('isPublished', true)
+  })
+  .all()
+```
+
+#### Working with Loaded Relationships
+
+```typescript
+const user = await User.query().load('profile').load('posts').firstOrFail()
+
+// ✅ Type-safe access with IntelliSense
+if (user.profile) {
+  console.log(user.profile.firstName) // ✅ Type: string
+  console.log(user.profile.lastName) // ✅ Type: string
+}
+
+// ✅ Array relationships with full type safety
+if (user.posts) {
+  user.posts.forEach((post) => {
+    console.log(post.title) // ✅ Type: string
+    console.log(post.content) // ✅ Type: string
+  })
+
+  // ✅ Standard array methods work
+  const publishedPosts = user.posts.filter((post) => post.isPublished)
+  const postTitles = user.posts.map((post) => post.title)
+}
+```
+
+#### Relationship Operations
+
+```typescript
+// Create related models
+const user = await User.create({ name: 'John', email: 'john@example.com' })
+
+// Create related profile
+const profile = await Profile.create({
+  firstName: 'John',
+  lastName: 'Doe',
+  userId: user._id,
+})
+
+// Create related posts
+const posts = await Post.createMany([
+  { title: 'First Post', content: 'Content 1', authorId: user._id },
+  { title: 'Second Post', content: 'Content 2', authorId: user._id },
+])
+
+// Associate existing models (for belongsTo relationships)
+const existingUser = await User.findOrFail('507f1f77bcf86cd799439011')
+const newProfile = new Profile()
+newProfile.firstName = 'Jane'
+newProfile.lastName = 'Smith'
+await newProfile.user.associate(existingUser)
 ```
 
 ### Basic CRUD Operations
@@ -758,6 +928,8 @@ const updatedCount = await User.query().where('age', '>=', 18).update({ status: 
 
 ### Column Decorators
 
+The ODM provides several decorators for defining model properties and their behavior.
+
 #### Basic Column
 
 ```typescript
@@ -796,6 +968,30 @@ declare updatedAt: DateTime
 declare birthDate: DateTime
 ```
 
+#### Decimal Columns
+
+For precise decimal arithmetic and financial data, use the `@column.decimal()` decorator to properly handle MongoDB's Decimal128 type:
+
+```typescript
+@column.decimal()
+declare price: number
+
+@column.decimal()
+declare earnings: number
+
+@column.decimal()
+declare taxAmount: number
+```
+
+**Why use `@column.decimal()`?**
+
+Without the decimal decorator, MongoDB decimal values are serialized as objects like `{ "$numberDecimal": "100.99" }` instead of proper numbers. The decimal decorator:
+
+- Stores values as MongoDB Decimal128 for precision
+- Deserializes to JavaScript numbers for calculations
+- Serializes to proper numbers in JSON responses
+- Handles both `Decimal128` and `{ $numberDecimal: "..." }` formats from MongoDB
+
 #### Custom Serialization
 
 ```typescript
@@ -805,6 +1001,210 @@ declare birthDate: DateTime
 })
 declare name: string
 ```
+
+#### Computed Properties
+
+Computed properties are getter-only properties that are calculated from other model attributes. They are included in JSON serialization but excluded from database operations.
+
+```typescript
+import { BaseModel, column, computed } from 'adonis-odm'
+import { DateTime } from 'luxon'
+
+export default class User extends BaseModel {
+  @column({ isPrimary: true })
+  declare _id: string
+
+  @column()
+  declare firstName: string
+
+  @column()
+  declare lastName: string
+
+  @column()
+  declare email: string
+
+  @column()
+  declare salary: number
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  // Basic computed property
+  @computed()
+  get fullName(): string {
+    return `${this.firstName} ${this.lastName}`
+  }
+
+  // Computed property with custom serialization name
+  @computed({ serializeAs: 'display_name' })
+  get displayName(): string {
+    return `${this.firstName} ${this.lastName}`.toUpperCase()
+  }
+
+  // Computed property that won't be serialized
+  @computed({ serializeAs: null })
+  get internalCalculation(): number {
+    return this.salary * 0.1 // This won't appear in JSON output
+  }
+
+  // Complex computed property
+  @computed()
+  get profileSummary(): string {
+    const yearsActive = DateTime.now().diff(this.createdAt, 'years').years
+    return `${this.fullName} (${Math.floor(yearsActive)} years active)`
+  }
+
+  // Computed property based on relationships
+  @computed()
+  get hasProfile(): boolean {
+    return this.profile !== undefined && this.profile !== null
+  }
+}
+```
+
+#### Using Computed Properties
+
+```typescript
+const user = await User.create({
+  firstName: 'John',
+  lastName: 'Doe',
+  email: 'john@example.com',
+  salary: 50000,
+})
+
+// Access computed properties directly
+console.log(user.fullName) // "John Doe"
+console.log(user.displayName) // "JOHN DOE"
+console.log(user.profileSummary) // "John Doe (0 years active)"
+
+// Computed properties are included in JSON serialization
+const json = user.toJSON()
+console.log(json)
+// Output:
+// {
+//   _id: "...",
+//   first_name: "John",
+//   last_name: "Doe",
+//   email: "john@example.com",
+//   salary: 50000,
+//   created_at: "2024-01-01T00:00:00.000Z",
+//   updated_at: "2024-01-01T00:00:00.000Z",
+//   full_name: "John Doe",
+//   display_name: "JOHN DOE",
+//   profile_summary: "John Doe (0 years active)",
+//   has_profile: false
+//   // Note: internal_calculation is not included (serializeAs: null)
+// }
+
+// Computed properties are NOT included in database operations
+await user.save() // Only saves actual column data, not computed properties
+```
+
+#### Computed Properties with Relationships
+
+```typescript
+export default class User extends BaseModel {
+  @column({ isPrimary: true })
+  declare _id: string
+
+  @column()
+  declare name: string
+
+  @hasOne(() => Profile)
+  declare profile: HasOne<typeof Profile>
+
+  @hasMany(() => Post)
+  declare posts: HasMany<typeof Post>
+
+  // Computed property from loaded relationship
+  @computed()
+  get fullName(): string {
+    return this.profile?.fullName ?? this.name
+  }
+
+  // Computed property with relationship data
+  @computed()
+  get postCount(): number {
+    return this.posts?.length ?? 0
+  }
+
+  // Complex computed property
+  @computed()
+  get userStats(): object {
+    return {
+      name: this.name,
+      hasProfile: !!this.profile,
+      totalPosts: this.postCount,
+      joinedDate: this.createdAt.toFormat('yyyy-MM-dd'),
+    }
+  }
+}
+
+// Usage with loaded relationships
+const user = await User.query().load('profile').load('posts').firstOrFail()
+
+console.log(user.fullName) // Uses profile data if available
+console.log(user.postCount) // Returns actual post count
+console.log(user.userStats) // Complex computed object
+```
+
+#### When to Use @computed() vs Regular Getters
+
+**Use `@computed()` decorator when:**
+
+- You want the property included in JSON serialization
+- You need custom serialization names (`serializeAs`)
+- You want to exclude from serialization (`serializeAs: null`)
+- The property represents computed data that should be part of the model's public API
+
+**Use regular getters when:**
+
+- You want simple helper methods that don't need serialization
+- The getter is for internal use only
+- You're working with embedded documents where serialization is handled differently
+
+```typescript
+export default class User extends BaseModel {
+  @column()
+  declare firstName: string
+
+  @column()
+  declare lastName: string
+
+  // ✅ Use @computed() for serialized properties
+  @computed()
+  get fullName(): string {
+    return `${this.firstName} ${this.lastName}`
+  }
+
+  // ✅ Use regular getter for internal helpers
+  get initials(): string {
+    return `${this.firstName[0]}${this.lastName[0]}`
+  }
+
+  // ✅ Use @computed() with custom serialization
+  @computed({ serializeAs: 'display_name' })
+  get displayName(): string {
+    return this.fullName.toUpperCase()
+  }
+
+  // ✅ Use @computed() to exclude from serialization
+  @computed({ serializeAs: null })
+  get internalId(): string {
+    return `internal_${this._id}`
+  }
+}
+```
+
+#### Computed Properties Best Practices
+
+1. **Keep computations lightweight** - Avoid heavy calculations in getters
+2. **Use appropriate return types** - TypeScript will infer types automatically
+3. **Handle null/undefined cases** - Always check for loaded relationships
+4. **Use meaningful names** - Make computed property names descriptive
+5. **Consider serialization** - Use `serializeAs` to control JSON output
+6. **Avoid side effects** - Computed properties should be pure functions
+7. **Choose the right pattern** - Use `@computed()` for serialized properties, regular getters for helpers
 
 ### Model Lifecycle
 
@@ -824,6 +1224,202 @@ console.log(user.$isPersisted) // true
 user.name = 'Jane'
 console.log(user.$dirty) // { name: 'Jane' }
 ```
+
+### Lifecycle Hooks
+
+The ODM provides a comprehensive hook system that allows you to execute custom logic at various points in the model lifecycle. Hooks are defined using decorators and are executed automatically.
+
+#### Available Hooks
+
+```typescript
+import {
+  BaseModel,
+  column,
+  beforeSave,
+  afterSave,
+  beforeCreate,
+  afterCreate,
+  beforeUpdate,
+  afterUpdate,
+  beforeDelete,
+  afterDelete,
+  beforeFind,
+  afterFind,
+  beforeFetch,
+  afterFetch,
+} from 'adonis-odm'
+
+export default class User extends BaseModel {
+  @column({ isPrimary: true })
+  declare _id: string
+
+  @column()
+  declare name: string
+
+  @column()
+  declare email: string
+
+  @column()
+  declare password: string
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+
+  // Hooks that run before/after save operations (create and update)
+  @beforeSave()
+  static async hashPassword(user: User) {
+    if (user.$dirty.password) {
+      user.password = await hash(user.password)
+    }
+  }
+
+  @afterSave()
+  static async logSave(user: User) {
+    console.log(`User ${user.name} was saved`)
+  }
+
+  // Hooks that run before/after create operations
+  @beforeCreate()
+  static async validateEmail(user: User) {
+    const existingUser = await User.findBy('email', user.email)
+    if (existingUser) {
+      throw new Error('Email already exists')
+    }
+  }
+
+  @afterCreate()
+  static async sendWelcomeEmail(user: User) {
+    // Send welcome email logic
+    console.log(`Welcome email sent to ${user.email}`)
+  }
+
+  // Hooks that run before/after update operations
+  @beforeUpdate()
+  static async validateUpdate(user: User) {
+    if (user.$dirty.email) {
+      // Validate email change
+      console.log('Email is being changed')
+    }
+  }
+
+  @afterUpdate()
+  static async logUpdate(user: User) {
+    console.log(`User ${user.name} was updated`)
+  }
+
+  // Hooks that run before/after delete operations
+  @beforeDelete()
+  static async checkDependencies(user: User) {
+    const posts = await Post.query().where('authorId', user._id).count()
+    if (posts > 0) {
+      throw new Error('Cannot delete user with existing posts')
+    }
+  }
+
+  @afterDelete()
+  static async cleanup(user: User) {
+    // Cleanup related data
+    console.log(`Cleanup completed for user ${user.name}`)
+  }
+
+  // Hooks that run before/after find operations
+  @beforeFind()
+  static async logFind(query: ModelQueryBuilder<any, User>) {
+    console.log('Finding user...')
+  }
+
+  @afterFind()
+  static async logFoundUser(user: User | null) {
+    if (user) {
+      console.log(`Found user: ${user.name}`)
+    }
+  }
+
+  // Hooks that run before/after fetch operations (multiple records)
+  @beforeFetch()
+  static async logFetch(query: ModelQueryBuilder<any, User>) {
+    console.log('Fetching users...')
+  }
+
+  @afterFetch()
+  static async logFetchedUsers(users: User[]) {
+    console.log(`Fetched ${users.length} users`)
+  }
+}
+```
+
+#### Hook Execution Order
+
+Hooks are executed in the following order:
+
+**For Create Operations:**
+
+1. `beforeSave`
+2. `beforeCreate`
+3. Database operation
+4. `afterCreate`
+5. `afterSave`
+
+**For Update Operations:**
+
+1. `beforeSave`
+2. `beforeUpdate`
+3. Database operation
+4. `afterUpdate`
+5. `afterSave`
+
+**For Delete Operations:**
+
+1. `beforeDelete`
+2. Database operation
+3. `afterDelete`
+
+**For Find Operations:**
+
+1. `beforeFind`
+2. Database operation
+3. `afterFind`
+
+**For Fetch Operations:**
+
+1. `beforeFetch`
+2. Database operation
+3. `afterFetch`
+
+#### Aborting Operations
+
+Before hooks can abort operations by returning `false`:
+
+```typescript
+export default class User extends BaseModel {
+  @beforeSave()
+  static async validateUser(user: User) {
+    if (!user.email.includes('@')) {
+      console.log('Invalid email format')
+      return false // Aborts the save operation
+    }
+  }
+
+  @beforeDelete()
+  static async preventAdminDeletion(user: User) {
+    if (user.role === 'admin') {
+      console.log('Cannot delete admin user')
+      return false // Aborts the delete operation
+    }
+  }
+}
+```
+
+#### Hook Best Practices
+
+1. **Keep hooks lightweight** - Avoid heavy computations in hooks
+2. **Use async/await** - Hooks support asynchronous operations
+3. **Handle errors gracefully** - Use try/catch blocks for error handling
+4. **Return false to abort** - Use return false in before hooks to prevent operations
+5. **Use appropriate hook types** - Choose the right hook for your use case
 
 ### Database Transactions
 
@@ -1004,6 +1600,403 @@ export default class User extends BaseModel {
     return 'secondary' // Use a different connection
   }
 }
+
+// Using different connections in queries
+const primaryUsers = await User.query().all() // Uses default connection
+const analyticsUsers = await User.query({ connection: 'analytics' }).all() // Uses analytics connection
+
+// Direct database access with specific connections
+const primaryDb = db.connection('primary')
+const analyticsDb = db.connection('analytics')
+```
+
+### Error Handling
+
+The ODM provides comprehensive error handling with custom exception types for different scenarios.
+
+#### Exception Types
+
+```typescript
+import {
+  MongoOdmException,
+  ModelNotFoundException,
+  ConnectionException,
+  DatabaseOperationException,
+  ValidationException,
+  TransactionException,
+} from 'adonis-odm'
+
+// Base exception for all ODM errors
+try {
+  // ODM operations
+} catch (error) {
+  if (error instanceof MongoOdmException) {
+    console.log('ODM Error:', error.message)
+  }
+}
+
+// Model not found exception
+try {
+  const user = await User.findOrFail('invalid-id')
+} catch (error) {
+  if (error instanceof ModelNotFoundException) {
+    console.log('User not found:', error.message)
+    // Error message: "User with identifier "invalid-id" not found"
+  }
+}
+
+// Connection exception
+try {
+  await db.connect()
+} catch (error) {
+  if (error instanceof ConnectionException) {
+    console.log('Connection failed:', error.message)
+    // Error message: "Failed to connect to MongoDB connection "primary": ..."
+  }
+}
+
+// Database operation exception
+try {
+  await User.query().where('invalid.field', 'value').all()
+} catch (error) {
+  if (error instanceof DatabaseOperationException) {
+    console.log('Database operation failed:', error.message)
+    // Error message: "Database operation "find" failed: ..."
+  }
+}
+
+// Validation exception
+try {
+  const user = new User()
+  user.email = 'invalid-email'
+  await user.save()
+} catch (error) {
+  if (error instanceof ValidationException) {
+    console.log('Validation failed:', error.message)
+    // Error message: "Validation failed for field "email" with value "invalid-email": must be a valid email"
+  }
+}
+
+// Transaction exception
+try {
+  await db.transaction(async (trx) => {
+    // Transaction operations that fail
+    throw new Error('Something went wrong')
+  })
+} catch (error) {
+  if (error instanceof TransactionException) {
+    console.log('Transaction failed:', error.message)
+    // Error message: "Transaction operation "commit" failed: ..."
+  }
+}
+```
+
+#### Error Handling Best Practices
+
+```typescript
+// 1. Use specific exception types for targeted error handling
+export default class UserController {
+  async show({ params, response }: HttpContext) {
+    try {
+      const user = await User.findOrFail(params.id)
+      return user
+    } catch (error) {
+      if (error instanceof ModelNotFoundException) {
+        return response.status(404).json({ error: 'User not found' })
+      }
+      throw error // Re-throw other errors
+    }
+  }
+
+  async store({ request, response }: HttpContext) {
+    try {
+      const userData = request.only(['name', 'email'])
+      const user = await User.create(userData)
+      return response.status(201).json(user)
+    } catch (error) {
+      if (error instanceof ValidationException) {
+        return response.status(422).json({ error: error.message })
+      }
+      if (error instanceof DatabaseOperationException) {
+        return response.status(500).json({ error: 'Database error occurred' })
+      }
+      throw error
+    }
+  }
+}
+
+// 2. Use global exception handler for consistent error responses
+export default class HttpExceptionHandler extends ExceptionHandler {
+  async handle(error: unknown, ctx: HttpContext) {
+    if (error instanceof ModelNotFoundException) {
+      return ctx.response.status(404).json({
+        error: 'Resource not found',
+        message: error.message,
+      })
+    }
+
+    if (error instanceof ValidationException) {
+      return ctx.response.status(422).json({
+        error: 'Validation failed',
+        message: error.message,
+      })
+    }
+
+    if (error instanceof ConnectionException) {
+      return ctx.response.status(503).json({
+        error: 'Service unavailable',
+        message: 'Database connection failed',
+      })
+    }
+
+    return super.handle(error, ctx)
+  }
+}
+
+// 3. Graceful error handling in transactions
+async function transferData() {
+  try {
+    await db.transaction(async (trx) => {
+      const user = await User.create({ name: 'John' }, { client: trx })
+      const profile = await Profile.create({ userId: user._id }, { client: trx })
+
+      // If any operation fails, transaction is automatically rolled back
+      return { user, profile }
+    })
+  } catch (error) {
+    if (error instanceof TransactionException) {
+      console.log('Transaction failed and was rolled back')
+    }
+    // Handle other errors
+  }
+}
+```
+
+## Performance & Advanced Features
+
+### Bulk Operations
+
+The ODM supports efficient bulk operations for better performance:
+
+```typescript
+// Bulk create
+const users = await User.createMany([
+  { name: 'User 1', email: 'user1@example.com' },
+  { name: 'User 2', email: 'user2@example.com' },
+  { name: 'User 3', email: 'user3@example.com' },
+])
+
+// Bulk update
+const updateCount = await User.query().where('isActive', false).update({ status: 'inactive' })
+
+// Bulk delete
+const deleteCount = await User.query()
+  .where('lastLoginAt', '<', DateTime.now().minus({ months: 6 }))
+  .delete()
+
+// Bulk upsert (update or create)
+const results = await User.updateOrCreateMany(
+  'email', // Key field
+  [
+    { email: 'user1@example.com', name: 'Updated User 1' },
+    { email: 'user4@example.com', name: 'New User 4' },
+  ]
+)
+```
+
+### Connection Pooling
+
+MongoDB connection pooling is automatically configured for optimal performance:
+
+```typescript
+// Configure connection pool in config/odm.ts
+const odmConfig = defineConfig({
+  connections: {
+    mongodb: {
+      client: 'mongodb',
+      connection: {
+        url: env.get('MONGO_URI'),
+        options: {
+          maxPoolSize: 20, // Maximum connections in pool
+          minPoolSize: 5, // Minimum connections in pool
+          maxIdleTimeMS: 30000, // Close connections after 30s idle
+          serverSelectionTimeoutMS: 5000, // Timeout for server selection
+          socketTimeoutMS: 0, // No socket timeout
+          connectTimeoutMS: 10000, // 10s connection timeout
+        },
+      },
+    },
+  },
+})
+```
+
+### Query Optimization
+
+```typescript
+// Use indexes for better query performance
+const users = await User.query()
+  .where('email', 'john@example.com') // Ensure email field is indexed
+  .where('isActive', true) // Compound index on email + isActive
+  .first()
+
+// Limit fields to reduce data transfer
+const users = await User.query()
+  .select(['name', 'email']) // Only fetch required fields
+  .where('isActive', true)
+  .all()
+
+// Use pagination for large datasets
+const paginatedUsers = await User.query()
+  .where('isActive', true)
+  .orderBy('createdAt', 'desc')
+  .paginate(1, 50) // Page 1, 50 records per page
+
+// Efficient counting
+const activeUserCount = await User.query().where('isActive', true).count() // More efficient than fetching all records
+```
+
+### Relationship Loading Optimization
+
+```typescript
+// Eager load relationships to prevent N+1 queries
+const users = await User.query()
+  .load('profile')
+  .load('posts', (postQuery) => {
+    postQuery.limit(5).orderBy('createdAt', 'desc')
+  })
+  .where('isActive', true)
+  .all()
+
+// Bulk load relationships for multiple models
+const userIds = ['id1', 'id2', 'id3']
+const users = await User.query().whereIn('_id', userIds).load('profile').all()
+```
+
+### Embedded Document Performance
+
+```typescript
+// Efficient embedded document queries
+const users = await User.query()
+  .embed('profiles', (profileQuery) => {
+    profileQuery.where('age', '>', 25).orderBy('age', 'desc').limit(3) // Limit embedded results
+  })
+  .where('isActive', true)
+  .all()
+
+// Aggregation on embedded documents
+const userStats = await User.query()
+  .where('profiles.age', '>', 18)
+  .aggregate([
+    { $unwind: '$profiles' },
+    { $group: { _id: null, avgAge: { $avg: '$profiles.age' } } },
+  ])
+```
+
+### Caching Strategies
+
+```typescript
+// Model-level caching (implement in your application)
+class CachedUser extends User {
+  static async findCached(id: string): Promise<User | null> {
+    const cacheKey = `user:${id}`
+    let user = await cache.get(cacheKey)
+
+    if (!user) {
+      user = await this.find(id)
+      if (user) {
+        await cache.set(cacheKey, user, { ttl: 300 }) // 5 minutes
+      }
+    }
+
+    return user
+  }
+}
+
+// Query result caching
+const cacheKey = 'active-users'
+let activeUsers = await cache.get(cacheKey)
+
+if (!activeUsers) {
+  activeUsers = await User.query().where('isActive', true).all()
+  await cache.set(cacheKey, activeUsers, { ttl: 60 }) // 1 minute
+}
+```
+
+### Advanced Query Patterns
+
+```typescript
+// Complex aggregation pipelines
+const userStats = await User.aggregate([
+  { $match: { isActive: true } },
+  {
+    $group: {
+      _id: '$department',
+      count: { $sum: 1 },
+      avgAge: { $avg: '$age' },
+      maxSalary: { $max: '$salary' },
+    },
+  },
+  { $sort: { count: -1 } },
+])
+
+// Geospatial queries (if using location data)
+const nearbyUsers = await User.query()
+  .where('location', 'near', {
+    geometry: { type: 'Point', coordinates: [longitude, latitude] },
+    maxDistance: 1000, // meters
+  })
+  .all()
+
+// Text search
+const searchResults = await User.query()
+  .where('$text', { $search: 'john developer' })
+  .orderBy({ score: { $meta: 'textScore' } })
+  .all()
+
+// Complex filtering with $expr
+const users = await User.query()
+  .where('$expr', {
+    $gt: [{ $size: '$posts' }, 10], // Users with more than 10 posts
+  })
+  .all()
+```
+
+### Memory Management
+
+```typescript
+// Use streams for large datasets
+const userStream = User.query().where('isActive', true).stream()
+
+userStream.on('data', (user) => {
+  // Process each user individually
+  processUser(user)
+})
+
+userStream.on('end', () => {
+  console.log('Finished processing all users')
+})
+
+// Cursor-based pagination for large datasets
+let cursor = null
+const batchSize = 1000
+
+do {
+  const query = User.query().limit(batchSize)
+  if (cursor) {
+    query.where('_id', '>', cursor)
+  }
+
+  const users = await query.orderBy('_id').all()
+
+  if (users.length > 0) {
+    cursor = users[users.length - 1]._id
+    await processBatch(users)
+  }
+
+  if (users.length < batchSize) {
+    break // No more data
+  }
+} while (true)
 ```
 
 ## API Reference
@@ -1040,6 +2033,98 @@ export default class User extends BaseModel {
 - `$dirty` - Object containing modified attributes
 - `$original` - Original values before modifications
 - `$trx` - Associated transaction client (if any)
+
+### Column Decorators
+
+#### @column(options?)
+
+Define a regular database column.
+
+**Options:**
+
+- `isPrimary?: boolean` - Mark as primary key
+- `serialize?: (value: any) => any` - Custom serialization function
+- `deserialize?: (value: any) => any` - Custom deserialization function
+- `serializeAs?: string | null` - Custom JSON key name
+
+#### @column.dateTime(options?)
+
+Define a DateTime column with automatic timestamp handling.
+
+**Options:**
+
+- `autoCreate?: boolean` - Set timestamp on creation
+- `autoUpdate?: boolean` - Update timestamp on save
+- `serialize?: (value: DateTime) => any` - Custom serialization
+- `deserialize?: (value: any) => DateTime` - Custom deserialization
+
+#### @column.date(options?)
+
+Define a Date column.
+
+#### @column.embedded(model, type, options?)
+
+Define an embedded document column.
+
+**Parameters:**
+
+- `model: () => BaseModel` - Model class for the embedded document
+- `type: 'single' | 'many'` - Single document or array of documents
+- `options?: ColumnOptions` - Additional column options
+
+#### @computed(options?)
+
+Define a computed property (getter-only).
+
+**Options:**
+
+- `serializeAs?: string | null` - Custom JSON key name (null to exclude from serialization)
+
+### Relationship Decorators
+
+#### @hasOne(model, options?)
+
+Define a one-to-one relationship.
+
+**Parameters:**
+
+- `model: () => BaseModel` - Related model class
+- `options?: { localKey?: string, foreignKey?: string }` - Key configuration
+
+#### @hasMany(model, options?)
+
+Define a one-to-many relationship.
+
+**Parameters:**
+
+- `model: () => BaseModel` - Related model class
+- `options?: { localKey?: string, foreignKey?: string }` - Key configuration
+
+#### @belongsTo(model, options?)
+
+Define a many-to-one relationship.
+
+**Parameters:**
+
+- `model: () => BaseModel` - Related model class
+- `options?: { localKey?: string, foreignKey?: string }` - Key configuration
+
+### Hook Decorators
+
+#### Lifecycle Hooks
+
+- `@beforeSave()` - Before create or update
+- `@afterSave()` - After create or update
+- `@beforeCreate()` - Before create only
+- `@afterCreate()` - After create only
+- `@beforeUpdate()` - Before update only
+- `@afterUpdate()` - After update only
+- `@beforeDelete()` - Before delete
+- `@afterDelete()` - After delete
+- `@beforeFind()` - Before find operations
+- `@afterFind()` - After find operations
+- `@beforeFetch()` - Before fetch operations
+- `@afterFetch()` - After fetch operations
 
 ### Query Builder
 
@@ -1240,24 +2325,464 @@ The `EmbeddedQueryBuilder` provides comprehensive querying capabilities for embe
 - `query(modelConstructor)` - Create query builder within transaction
 - `getSession()` - Get underlying MongoDB ClientSession
 
+## CLI Commands
+
+The MongoDB ODM provides Ace commands for generating models and managing your database.
+
+### Generate Models
+
+Generate a new ODM model:
+
+```bash
+node ace make:odm-model User
+```
+
+This creates a new model file in `app/models/` with the basic structure:
+
+```typescript
+import { BaseModel, column } from 'adonis-odm'
+import { DateTime } from 'luxon'
+
+export default class User extends BaseModel {
+  @column({ isPrimary: true })
+  declare _id: string
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+
+  static getCollectionName(): string {
+    return 'users'
+  }
+}
+```
+
+**Available Commands:**
+
+- `make:odm-model <ModelName>` - Generate a new ODM model class
+
+## Testing
+
+The MongoDB ODM provides comprehensive testing support with both unit tests and integration tests.
+
+### Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run integration tests with real MongoDB
+npm run test:integration
+
+# Run all tests (unit + integration)
+npm run test:all
+
+# Run tests in watch mode
+npm run test:watch
+
+# Run tests with coverage
+npm run test:coverage
+```
+
+### Docker Testing
+
+For integration tests, the package includes Docker support:
+
+```bash
+# Start MongoDB with Docker and run tests
+npm run test:docker
+
+# Keep containers running after tests (useful for debugging)
+npm run test:docker:keep
+```
+
+### Writing Tests for Your Models
+
+```typescript
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { User, Profile } from '#models'
+import db from 'adonis-odm/services/db'
+
+test.describe('User Model', () => {
+  test.beforeEach(async () => {
+    // Clean up database before each test
+    await User.query().delete()
+    await Profile.query().delete()
+  })
+
+  test('should create a user with embedded profile', async () => {
+    const user = await User.create({
+      name: 'John Doe',
+      email: 'john@example.com',
+      profile: {
+        firstName: 'John',
+        lastName: 'Doe',
+        age: 30,
+      },
+    })
+
+    assert.strictEqual(user.name, 'John Doe')
+    assert.strictEqual(user.profile?.firstName, 'John')
+    assert.ok(user.$isPersisted)
+  })
+
+  test('should load relationships', async () => {
+    const user = await User.create({
+      name: 'Jane Smith',
+      email: 'jane@example.com',
+    })
+
+    const profile = await Profile.create({
+      firstName: 'Jane',
+      lastName: 'Smith',
+      userId: user._id,
+    })
+
+    const userWithProfile = await User.query().load('profile').findOrFail(user._id)
+
+    assert.ok(userWithProfile.profile)
+    assert.strictEqual(userWithProfile.profile.firstName, 'Jane')
+  })
+
+  test('should handle transactions', async () => {
+    const result = await db.transaction(async (trx) => {
+      const user = await User.create(
+        {
+          name: 'Transaction User',
+          email: 'transaction@example.com',
+        },
+        { client: trx }
+      )
+
+      const profile = await Profile.create(
+        {
+          firstName: 'Transaction',
+          lastName: 'User',
+          userId: user._id,
+        },
+        { client: trx }
+      )
+
+      return { user, profile }
+    })
+
+    assert.strictEqual(result.user.name, 'Transaction User')
+    assert.strictEqual(result.profile.firstName, 'Transaction')
+  })
+
+  test('should execute hooks', async () => {
+    let hookExecuted = false
+
+    // Temporarily add a hook for testing
+    const originalHooks = User.getMetadata().hooks
+    User.getMetadata().hooks = new Map([['afterCreate', ['testHook']]])
+
+    // Add the hook method
+    ;(User as any).testHook = () => {
+      hookExecuted = true
+    }
+
+    await User.create({
+      name: 'Hook Test',
+      email: 'hook@example.com',
+    })
+
+    assert.ok(hookExecuted)
+
+    // Restore original hooks
+    User.getMetadata().hooks = originalHooks
+  })
+
+  test('should handle embedded document queries', async () => {
+    const user = await User.create({
+      name: 'Embedded Test',
+      email: 'embedded@example.com',
+      profiles: [
+        { firstName: 'John', lastName: 'Doe', age: 30 },
+        { firstName: 'Jane', lastName: 'Smith', age: 25 },
+      ],
+    })
+
+    const userWithFilteredProfiles = await User.query()
+      .embed('profiles', (profileQuery) => {
+        profileQuery.where('age', '>', 28)
+      })
+      .findOrFail(user._id)
+
+    assert.strictEqual(userWithFilteredProfiles.profiles?.length, 1)
+    assert.strictEqual(userWithFilteredProfiles.profiles?.[0].firstName, 'John')
+  })
+})
+```
+
+### Test Utilities
+
+For testing, you can use the standard MongoDB ODM features:
+
+```typescript
+import db from 'adonis-odm/services/db'
+import { User, Profile } from '#models'
+
+// Clean all collections manually
+await User.query().delete()
+await Profile.query().delete()
+
+// Or clean specific collections
+await db.collection('users').deleteMany({})
+await db.collection('profiles').deleteMany({})
+
+// Create test data
+const testUsers = await User.createMany([
+  { name: 'Test User 1', email: 'test1@example.com' },
+  { name: 'Test User 2', email: 'test2@example.com' },
+])
+
+// Create test transaction
+const result = await db.transaction(async (trx) => {
+  // Your test operations within transaction
+  const user = await User.create({ name: 'Test' }, { client: trx })
+  return user
+})
+```
+
+### Testing Best Practices
+
+1. **Clean database between tests** - Ensure test isolation
+2. **Use transactions for test data** - Easy cleanup and rollback
+3. **Test both success and error cases** - Include exception handling
+4. **Mock external dependencies** - Focus on ODM functionality
+5. **Use descriptive test names** - Make tests self-documenting
+
 ## Examples
 
-The MongoDB ODM provides comprehensive functionality as demonstrated in the CRUD controller at `app/controllers/cruds_controller.ts`. This controller showcases all the key features including:
+The MongoDB ODM provides comprehensive functionality as demonstrated in the examples directory:
+
+### Example Files
+
+- **`examples/app/controllers/cruds_controller.ts`** - Complete CRUD operations showcase
+- **`examples/app/models/`** - Various model examples with different relationship types
+- **`examples/simple_db_usage.ts`** - Basic usage patterns
+- **`examples/config/odm.ts`** - Configuration examples
+
+### Key Features Demonstrated
 
 - Type-safe embedded document operations
 - Advanced query building with the `.embed()` method
 - CRUD operations on both single and array embedded documents
-- Transaction support
-- Relationship loading and filtering
+- Transaction support with error handling
+- Relationship loading and filtering with type safety
+- Lifecycle hooks implementation
+- Error handling patterns
 
 ## Contributing
 
-1. Fork the repository
-2. Create your feature branch
-3. Add tests for your changes
-4. Ensure all tests pass
-5. Submit a pull request
+We welcome contributions to the MongoDB ODM! Here's how you can help:
+
+### Development Setup
+
+1. **Fork and Clone**
+
+   ```bash
+   git clone https://github.com/your-username/adonis-odm.git
+   cd adonis-odm
+   ```
+
+2. **Install Dependencies**
+
+   ```bash
+   npm install
+   ```
+
+3. **Set Up Development Environment**
+
+   ```bash
+   # Copy environment variables
+   cp .env.example .env
+
+   # Start MongoDB with Docker (for testing)
+   docker-compose up -d mongodb
+   ```
+
+4. **Run Tests**
+
+   ```bash
+   # Run all tests
+   npm test
+
+   # Run tests with coverage
+   npm run test:coverage
+
+   # Run integration tests
+   npm run test:integration
+   ```
+
+### Development Workflow
+
+1. **Create a Feature Branch**
+
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Make Your Changes**
+
+   - Follow the existing code style
+   - Add tests for new functionality
+   - Update documentation as needed
+
+3. **Run Quality Checks**
+
+   ```bash
+   # Lint code
+   npm run lint
+
+   # Format code
+   npm run format
+
+   # Type check
+   npm run typecheck
+
+   # Run all tests
+   npm run test:all
+   ```
+
+4. **Build the Package**
+
+   ```bash
+   npm run compile
+   ```
+
+5. **Submit a Pull Request**
+   - Provide a clear description of your changes
+   - Include tests for new features
+   - Ensure all CI checks pass
+
+### Code Style Guidelines
+
+- **TypeScript**: Use strict TypeScript with proper type annotations
+- **ESLint**: Follow the configured ESLint rules
+- **Prettier**: Use Prettier for code formatting
+- **Naming**: Use descriptive names for variables, functions, and classes
+- **Comments**: Add JSDoc comments for public APIs
+
+### Testing Guidelines
+
+- **Unit Tests**: Test individual components in isolation
+- **Integration Tests**: Test real database operations
+- **Coverage**: Maintain high test coverage (>90%)
+- **Test Structure**: Use descriptive test names and organize tests logically
+
+### Documentation Guidelines
+
+- **README**: Keep the main README comprehensive and up-to-date
+- **JSDoc**: Document all public APIs with JSDoc comments
+- **Examples**: Provide practical examples for new features
+- **Changelog**: Update the changelog for all changes
+
+### Reporting Issues
+
+When reporting issues, please include:
+
+1. **Environment Information**
+
+   - Node.js version
+   - MongoDB version
+   - AdonisJS version
+   - Package version
+
+2. **Reproduction Steps**
+
+   - Minimal code example
+   - Expected behavior
+   - Actual behavior
+
+3. **Error Messages**
+   - Full error stack traces
+   - Relevant log output
+
+### Feature Requests
+
+For feature requests, please:
+
+1. **Check Existing Issues** - Avoid duplicates
+2. **Provide Use Cases** - Explain why the feature is needed
+3. **Consider Implementation** - Suggest how it might work
+4. **Discuss First** - Open an issue before starting work
+
+### Release Process
+
+1. **Version Bumping**
+
+   ```bash
+   # Patch release (bug fixes)
+   npm run release:patch
+
+   # Minor release (new features)
+   npm run release:minor
+
+   # Major release (breaking changes)
+   npm run release:major
+   ```
+
+2. **Publishing**
+   ```bash
+   # Build and publish
+   npm run compile
+   npm publish
+   ```
+
+### Project Structure
+
+```
+adonis-odm/
+├── src/                    # Source code
+│   ├── base_model/        # BaseModel implementation
+│   ├── decorators/        # Column and hook decorators
+│   ├── query_builder/     # Query builder implementation
+│   ├── relationships/     # Relationship handling
+│   ├── embedded/          # Embedded document support
+│   ├── exceptions/        # Custom exceptions
+│   └── types/             # TypeScript type definitions
+├── providers/             # AdonisJS service providers
+├── commands/              # Ace commands
+├── services/              # Database services
+├── stubs/                 # Code generation templates
+├── examples/              # Usage examples
+├── tests/                 # Test files
+├── docs/                  # Documentation
+└── scripts/               # Build and utility scripts
+```
+
+### Getting Help
+
+- **GitHub Issues**: For bugs and feature requests
+- **Discussions**: For questions and community support
+- **Documentation**: Check the comprehensive docs in `/docs`
+- **Examples**: See practical examples in `/examples`
 
 ## License
 
-This project is licensed under the MIT License.
+This project is licensed under the MIT License. See the [LICENSE.md](LICENSE.md) file for details.
+
+## Acknowledgments
+
+- **AdonisJS Team** - For the excellent framework and Lucid ORM inspiration
+- **MongoDB Team** - For the robust MongoDB Node.js driver
+- **Contributors** - Thank you to all contributors who help improve this project
+
+## Changelog
+
+See [CHANGELOG.md](docs/CHANGELOG.md) for a detailed history of changes.
+
+## Support
+
+If you find this project helpful, please consider:
+
+- ⭐ Starring the repository
+- 🐛 Reporting bugs and issues
+- 💡 Suggesting new features
+- 🤝 Contributing code or documentation
+- 📢 Sharing with the community

--- a/demo_decimal_fix.ts
+++ b/demo_decimal_fix.ts
@@ -1,0 +1,59 @@
+import { BaseModel, column } from './src/index.js'
+
+// Example model with the decimal bug fix
+class Product extends BaseModel {
+  @column({ isPrimary: true })
+  declare _id: string
+
+  @column()
+  declare name: string
+
+  // ✅ SOLUTION: Use @column.decimal() for decimal values
+  @column.decimal()
+  declare earnings: number
+}
+
+// Simulate the original problem and show the fix
+function demonstrateFix() {
+  console.log('🔧 Decimal Serialization Bug Fix Demo\n')
+
+  // Create a product with decimal earnings
+  const product = new Product()
+  product.name = 'Test Product'
+  product.earnings = 100.99
+
+  console.log('✅ Original value:', product.earnings, typeof product.earnings)
+
+  // Simulate data coming from MongoDB with the problematic format
+  const mongoData = {
+    _id: '507f1f77bcf86cd799439011',
+    name: 'Test Product',
+    earnings: { $numberDecimal: '100.99' } // This is how MongoDB stores decimals
+  }
+
+  console.log('📥 MongoDB data format:', JSON.stringify(mongoData, null, 2))
+
+  // Hydrate the model from MongoDB data
+  product.hydrateFromDocument(mongoData as any)
+
+  console.log('✅ After hydration:', product.earnings, typeof product.earnings)
+
+  // Test JSON serialization (for API responses)
+  const json = product.toJSON()
+  console.log('📤 JSON serialization:', JSON.stringify(json, null, 2))
+
+  // Test document serialization (for MongoDB storage)
+  const document = product.toDocument()
+  console.log('💾 Document for MongoDB:', {
+    ...document,
+    earnings: `${document.earnings.constructor.name}(${document.earnings.toString()})`
+  })
+
+  console.log('\n🎉 SUCCESS: Decimal values are now properly handled!')
+  console.log('   - Stored as Decimal128 in MongoDB for precision')
+  console.log('   - Deserialized as numbers for calculations')
+  console.log('   - Serialized as numbers in JSON responses')
+}
+
+// Run the demonstration
+demonstrateFix()

--- a/examples/decimal_usage.ts
+++ b/examples/decimal_usage.ts
@@ -1,0 +1,134 @@
+import { BaseModel, column } from '../src/index.js'
+
+/**
+ * Example showing how to use the @column.decimal() decorator
+ * to properly handle decimal values in MongoDB
+ */
+
+export default class Product extends BaseModel {
+  @column({ isPrimary: true })
+  declare _id: string
+
+  @column()
+  declare name: string
+
+  // ❌ BEFORE: Using regular @column() for decimal values
+  // This would cause the bug where decimals are serialized as { "$numberDecimal": "100.99" }
+  // @column()
+  // declare earnings: number
+
+  // ✅ AFTER: Using @column.decimal() for decimal values
+  // This properly handles MongoDB Decimal128 serialization/deserialization
+  @column.decimal()
+  declare price: number
+
+  @column.decimal()
+  declare cost: number
+
+  @column.decimal()
+  declare earnings: number
+
+  @column()
+  declare category: string
+
+  // Computed property to calculate profit margin
+  get profitMargin(): number {
+    if (this.price === 0) return 0
+    return ((this.price - this.cost) / this.price) * 100
+  }
+}
+
+// Example usage:
+async function demonstrateDecimalHandling() {
+  // Create a product with decimal values
+  const product = new Product()
+  product.name = 'Premium Widget'
+  product.price = 100.99
+  product.cost = 75.50
+  product.earnings = 25.49
+  product.category = 'Electronics'
+
+  console.log('=== Original Values ===')
+  console.log('Price:', product.price, typeof product.price)
+  console.log('Cost:', product.cost, typeof product.cost)
+  console.log('Earnings:', product.earnings, typeof product.earnings)
+  console.log('Profit Margin:', product.profitMargin.toFixed(2) + '%')
+
+  // When saved to MongoDB, these will be stored as Decimal128
+  const document = product.toDocument()
+  console.log('\n=== MongoDB Document (for storage) ===')
+  console.log('Document price type:', document.price.constructor.name)
+  console.log('Document price value:', document.price.toString())
+
+  // When serialized to JSON (for API responses), these will be regular numbers
+  const json = product.toJSON()
+  console.log('\n=== JSON Output (for API responses) ===')
+  console.log('JSON:', JSON.stringify(json, null, 2))
+
+  // Simulate loading from MongoDB with Decimal128 values
+  console.log('\n=== Loading from MongoDB ===')
+  const mongoData = {
+    _id: '507f1f77bcf86cd799439011',
+    name: 'Premium Widget',
+    price: { $numberDecimal: '100.99' },
+    cost: { $numberDecimal: '75.50' },
+    earnings: { $numberDecimal: '25.49' },
+    category: 'Electronics'
+  }
+
+  const loadedProduct = new Product()
+  loadedProduct.hydrateFromDocument(mongoData as any)
+
+  console.log('Loaded price:', loadedProduct.price, typeof loadedProduct.price)
+  console.log('Loaded cost:', loadedProduct.cost, typeof loadedProduct.cost)
+  console.log('Loaded earnings:', loadedProduct.earnings, typeof loadedProduct.earnings)
+  console.log('Calculated profit margin:', loadedProduct.profitMargin.toFixed(2) + '%')
+
+  // JSON serialization works correctly
+  const loadedJson = loadedProduct.toJSON()
+  console.log('\n=== Loaded Product JSON ===')
+  console.log('JSON:', JSON.stringify(loadedJson, null, 2))
+}
+
+// Comparison: What happens with regular @column() decorator
+class ProductWithRegularColumn extends BaseModel {
+  @column({ isPrimary: true })
+  declare _id: string
+
+  @column()
+  declare name: string
+
+  // This will cause the serialization bug
+  @column()
+  declare price: number
+}
+
+async function demonstrateProblem() {
+  console.log('\n=== DEMONSTRATING THE PROBLEM ===')
+  
+  const product = new ProductWithRegularColumn()
+  product.name = 'Test Product'
+  product.price = 100.99
+
+  // Simulate data coming from MongoDB with decimal format
+  const mongoData = {
+    _id: '507f1f77bcf86cd799439011',
+    name: 'Test Product',
+    price: { $numberDecimal: '100.99' }
+  }
+
+  product.hydrateFromDocument(mongoData as any)
+  
+  // Without the decimal decorator, this would show the raw MongoDB decimal object
+  const json = product.toJSON()
+  console.log('Without @column.decimal():', JSON.stringify(json, null, 2))
+  
+  // The price would be serialized as { "$numberDecimal": "100.99" } instead of 100.99
+}
+
+// Run the demonstrations
+if (import.meta.url === `file://${process.argv[1]}`) {
+  demonstrateDecimalHandling()
+    .then(() => demonstrateProblem())
+    .catch(console.error)
+}

--- a/src/base_model/serialization_manager.ts
+++ b/src/base_model/serialization_manager.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { WithId, Document } from 'mongodb'
+import { WithId, Document, Decimal128 } from 'mongodb'
 import type { BaseModel } from './base_model.js'
 
 /**
@@ -217,6 +217,16 @@ export class SerializationManager {
     // Handle Date objects
     if (value instanceof Date) {
       return value.toISOString()
+    }
+
+    // Handle MongoDB Decimal128 objects
+    if (value instanceof Decimal128) {
+      return parseFloat(value.toString())
+    }
+
+    // Handle MongoDB decimal objects (BSON format)
+    if (value && typeof value === 'object' && value.$numberDecimal) {
+      return parseFloat(value.$numberDecimal)
     }
 
     // Handle arrays

--- a/tests/decimal.test.ts
+++ b/tests/decimal.test.ts
@@ -1,0 +1,139 @@
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { BaseModel } from '../src/base_model/base_model.js'
+import { column } from '../src/decorators/column.js'
+import { Decimal128 } from 'mongodb'
+
+test('decimal column serialization and deserialization', () => {
+  class TestModel extends BaseModel {
+    static tableName = 'test_models'
+
+    @column({ isPrimary: true })
+    declare _id: string
+
+    @column.decimal()
+    declare earnings: number
+
+    @column()
+    declare name: string
+  }
+
+  // Test model metadata
+  const metadata = TestModel.getMetadata()
+  assert.ok(metadata, 'Model should have metadata')
+  assert.ok(metadata.columns.has('earnings'), 'Should have earnings column')
+
+  // Test decimal column options
+  const earningsColumn = metadata.columns.get('earnings')
+  assert.ok(earningsColumn?.serialize, 'Earnings column should have serialize function')
+  assert.ok(earningsColumn?.deserialize, 'Earnings column should have deserialize function')
+
+  // Test model instance creation
+  const model = new TestModel()
+  model.name = 'Test User'
+  model.earnings = 100.99
+
+  // Test that the value is stored correctly
+  assert.equal(model.earnings, 100.99, 'Earnings should be stored as number')
+
+  // Test serialization to document (for MongoDB storage)
+  const document = model.toDocument()
+  assert.ok(document.earnings instanceof Decimal128, 'Earnings should be serialized to Decimal128')
+  assert.equal(document.earnings.toString(), '100.99', 'Decimal128 should contain correct value')
+
+  // Test JSON serialization (for API responses)
+  const json = model.toJSON()
+  assert.equal(typeof json.earnings, 'number', 'Earnings should be serialized to number in JSON')
+  assert.equal(json.earnings, 100.99, 'JSON earnings should have correct value')
+})
+
+test('decimal column handles MongoDB decimal objects', () => {
+  class TestModel extends BaseModel {
+    static tableName = 'test_models'
+
+    @column({ isPrimary: true })
+    declare _id: string
+
+    @column.decimal()
+    declare price: number
+  }
+
+  const model = new TestModel()
+
+  // Simulate data coming from MongoDB with $numberDecimal format
+  const mongoDecimalData = {
+    _id: '507f1f77bcf86cd799439011',
+    price: { $numberDecimal: '99.95' },
+  }
+
+  // Test hydration from MongoDB document
+  model.hydrateFromDocument(mongoDecimalData as any)
+
+  // The price should be deserialized to a number
+  assert.equal(typeof model.price, 'number', 'Price should be deserialized to number')
+  assert.equal(model.price, 99.95, 'Price should have correct value')
+
+  // Test JSON serialization
+  const json = model.toJSON()
+  assert.equal(json.price, 99.95, 'JSON price should be correct number')
+})
+
+test('decimal column handles Decimal128 objects', () => {
+  class TestModel extends BaseModel {
+    static tableName = 'test_models'
+
+    @column({ isPrimary: true })
+    declare _id: string
+
+    @column.decimal()
+    declare amount: number
+  }
+
+  const model = new TestModel()
+
+  // Simulate data coming from MongoDB with Decimal128
+  const decimal128Value = Decimal128.fromString('123.45')
+  const mongoData = {
+    _id: '507f1f77bcf86cd799439011',
+    amount: decimal128Value,
+  }
+
+  // Test hydration from MongoDB document
+  model.hydrateFromDocument(mongoData as any)
+
+  // The amount should be deserialized to a number
+  assert.equal(typeof model.amount, 'number', 'Amount should be deserialized to number')
+  assert.equal(model.amount, 123.45, 'Amount should have correct value')
+
+  // Test JSON serialization
+  const json = model.toJSON()
+  assert.equal(json.amount, 123.45, 'JSON amount should be correct number')
+})
+
+test('regular column without decimal decorator still works', () => {
+  class TestModel extends BaseModel {
+    static tableName = 'test_models'
+
+    @column({ isPrimary: true })
+    declare _id: string
+
+    @column()
+    declare regularNumber: number
+  }
+
+  const model = new TestModel()
+  model.regularNumber = 42.5
+
+  // Test that regular numbers work normally
+  assert.equal(model.regularNumber, 42.5, 'Regular number should work normally')
+
+  // Test JSON serialization
+  const json = model.toJSON()
+  // The naming strategy converts camelCase to snake_case for JSON
+  assert.equal(json.regular_number, 42.5, 'JSON regular number should work normally')
+
+  // Test document serialization
+  const document = model.toDocument()
+  // The naming strategy converts camelCase to snake_case for database too
+  assert.equal(document.regular_number, 42.5, 'Document regular number should work normally')
+})


### PR DESCRIPTION
#### Decimal Columns

For precise decimal arithmetic and financial data, use the `@column.decimal()` decorator to properly handle MongoDB's Decimal128 type:

```typescript
@column.decimal()
declare price: number

@column.decimal()
declare earnings: number

@column.decimal()
declare taxAmount: number
```

**Why use `@column.decimal()`?**

Without the decimal decorator, MongoDB decimal values are serialized as objects like `{ "$numberDecimal": "100.99" }` instead of proper numbers. The decimal decorator:

- Stores values as MongoDB Decimal128 for precision
- Deserializes to JavaScript numbers for calculations
- Serializes to proper numbers in JSON responses
- Handles both `Decimal128` and `{ $numberDecimal: "..." }` formats from MongoDB